### PR TITLE
Fix: Remove padding from tab content

### DIFF
--- a/index.html
+++ b/index.html
@@ -653,7 +653,6 @@ src="https://www.facebook.com/tr?id=482675157669768&ev=PageView&noscript=1"
             line-height: 1.7;
             color: var(--text-color);
             white-space: pre-line;
-            padding-top: 1.5rem;
         }
 
         .tab-content p {


### PR DESCRIPTION
This commit removes the `padding-top` from the `.tab-content` class. This change is intended to remove the extra space above the description text in the product detail page, as requested by you. Output:

---

🎨 This PR removes unnecessary top padding from tab content to improve the visual layout of product detail pages by eliminating unwanted whitespace above description text.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **CSS Styling**: Removed `padding-top: 1.5rem` from the `.tab-content` class in index.html
- **Visual Layout**: Eliminates extra vertical spacing above tab content text
- **User Experience**: Improves content density and visual hierarchy on product detail pages

### Technical Implementation
```mermaid
flowchart TD
    A[Tab Content Container] --> B[Before: padding-top: 1.5rem]
    A --> C[After: No top padding]
    B --> D[Extra whitespace above text]
    C --> E[Text starts immediately below tab header]
    E --> F[Improved visual layout]
```

### Impact
- **Visual Improvement**: Removes unwanted spacing that was creating visual gaps in the product detail layout
- **Content Density**: Better utilization of vertical space, allowing more content to be visible without scrolling
- **Design Consistency**: Aligns with design requirements for tighter content presentation

</details>

_Created with [Palmier](https://www.palmier.io)_